### PR TITLE
assets:precompileでハニーモードを有効にしろというメッセージが出たので変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,9 +23,9 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   # config.assets.js_compressor = :uglifier
-  
+
   # config.assets.css_compressor = :sass
-  # config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
以下のエラーが出た。
=> Uglifier::Error: Unexpected token: name (countNum). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).

ハニーモードを有効にしろということらしいので、production.rbの
config.assets.js_compressor = :uglifier　の部分を
config.assets.js_compressor = Uglifier.new(harmony: true)　に変更した。